### PR TITLE
AuditingFields: 필드 접근제어자를 protected로 수정

### DIFF
--- a/src/main/java/com/genielee/projectboard/domain/AuditingFields.java
+++ b/src/main/java/com/genielee/projectboard/domain/AuditingFields.java
@@ -23,18 +23,18 @@ public abstract class AuditingFields {
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @CreatedDate
     @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt; //생성일시
+    protected LocalDateTime createdAt; //생성일시
 
     @CreatedBy
     @Column(nullable = false, updatable = false, length = 100)
-    private String createdBy; //생성자
+    protected String createdBy; //생성자
 
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @LastModifiedDate
     @Column(nullable = false)
-    private LocalDateTime modifiedAt; //수정일시
+    protected LocalDateTime modifiedAt; //수정일시
 
     @LastModifiedBy
     @Column(nullable = false, length = 100)
-    private String modifiedBy; //수정자
+    protected String modifiedBy; //수정자
 }


### PR DESCRIPTION
이 pr은 AuditingFields의 필드 접근제어자를 추상 클래스에 맞게 protected로 수정한다.
이는 인증이 없는 상태에서 정보를 기록해야 할 때 필요할 예정.
대표적인 사례는 회원 가입.

This closes #75 